### PR TITLE
Allow you to specify a custom server

### DIFF
--- a/es/component.mjs
+++ b/es/component.mjs
@@ -9,6 +9,7 @@ const EVENTS = [
     "getJsCode",
     "onRun",
     "onError",
+    "server"
 ];
 
 const DATA_ATTRS = [


### PR DESCRIPTION
See this issue [for details](https://youtrack.jetbrains.com/issue/KTL-1030/Support-data-server-attribute-in-react-kotlin-playground-component).
